### PR TITLE
Fix test order

### DIFF
--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -177,7 +177,7 @@ func GeneratePathTestSuite(operations mqswag.NodeList, plan *TestPlan) {
 	}
 
 	pathName := operations[0].GetName()
-	sort.Sort(operations)
+	sort.Sort(mqswag.ByMethodPriority(operations))
 	testId := 0
 	testSuite := CreateTestSuite(fmt.Sprintf("%s", pathName), nil, plan)
 	createTest := &Test{}

--- a/mqgo/src/meqa/mqswag/dag.go
+++ b/mqgo/src/meqa/mqswag/dag.go
@@ -132,6 +132,24 @@ func (n NodeList) Less(i, j int) bool {
 	return wi < wj || (wi == wj && n[i].Name < n[j].Name)
 }
 
+type ByMethodPriority []*DAGNode
+
+func (n ByMethodPriority) Len() int {
+	return len(n)
+}
+
+func (n ByMethodPriority) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n ByMethodPriority) Less(i, j int) bool {
+	mi := methodWeight[n[i].GetMethod()]
+	mj := methodWeight[n[j].GetMethod()]
+	pi := n[i].Priority
+	pj := n[j].Priority
+	return mi < mj || (mi == mj && pi < pj) || (pi == pj && n[i].Name < n[j].Name)
+}
+
 // We expect a single thread on the server would handle the DAG creation and traversing. So no mutex for now.
 type DAG struct {
 	NameMap    map[string]*DAGNode // DAGNode name to node mapping.

--- a/mqgo/src/meqa/mqswag/dag.go
+++ b/mqgo/src/meqa/mqswag/dag.go
@@ -147,7 +147,7 @@ func (n ByMethodPriority) Less(i, j int) bool {
 	mj := methodWeight[n[j].GetMethod()]
 	pi := n[i].Priority
 	pj := n[j].Priority
-	return mi < mj || (mi == mj && pi < pj) || (pi == pj && n[i].Name < n[j].Name)
+	return mi < mj || (mi == mj && pi < pj) || (mi == mj && pi == pj && n[i].Name < n[j].Name)
 }
 
 // We expect a single thread on the server would handle the DAG creation and traversing. So no mutex for now.


### PR DESCRIPTION
**Problem**

Often, GET and PUT operations are executed after DELETE operation.
For example, in the petstore spec:

- **/user suite**: `put_updateUser_5` is executed after `delete_deleteUser_3` causing it to fail.
- **/pet suite**: `post_updatePetWithForm_1` and `get_getPetById_2` which take `petId` as parameter are executed before `post_addPet_5` which creates the pet object.

**Solution**

In each test suite, perform operations in the following order:

- Post
- Get
- Head
- Options
- Put
- Patch
- Delete

This ordering is already present in `methodWeight`.
In case the methods are same, give preference to the operation requiring lesser number of parameters. This is already set in the `Priority` of the node.