### PR TITLE
Remove nulls

### DIFF
--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -917,7 +917,9 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			}
 
 			// If there is a parameter passed in, just use it. Otherwise generate one.
-			if paramsMap[params.Name] == nil && globalParamsMap[params.Name] != nil {
+			_, inLocal := paramsMap[params.Name]
+			_, inGlobal := globalParamsMap[params.Name]
+			if !inLocal && inGlobal {
 				paramsMap[params.Name] = globalParamsMap[params.Name]
 			}
 			if _, ok := paramsMap[params.Name]; ok {

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/lucasjones/reggen"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -932,7 +932,24 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			return err
 		}
 	}
+	paramMaps := []*map[string]interface{}{&t.PathParams, &t.QueryParams, &t.HeaderParams, &t.FormParams}
+	for _, m := range paramMaps {
+		removeNulls(m)
+	}
+	bodyMap := t.BodyParams.(map[string]interface{})
+	removeNulls(&bodyMap)
+	t.BodyParams = bodyMap
 	return nil
+}
+
+func removeNulls(inputMap *map[string]interface{}) {
+	filteredMap := make(map[string]interface{})
+	for k, v := range *inputMap {
+		if v != nil {
+			filteredMap[k] = v
+		}
+	}
+	*inputMap = filteredMap
 }
 
 func GetOperationByMethod(item *spec.PathItem, method string) *spec.Operation {

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -936,9 +936,11 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 	for _, m := range paramMaps {
 		removeNulls(m)
 	}
-	bodyMap := t.BodyParams.(map[string]interface{})
-	removeNulls(&bodyMap)
-	t.BodyParams = bodyMap
+	if t.BodyParams != nil {
+		bodyMap := t.BodyParams.(map[string]interface{})
+		removeNulls(&bodyMap)
+		t.BodyParams = bodyMap
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
Currently every parameter (required and non-required) is generated and sent in a request. There's no way to explicitly ignore a non-required parameter.

**Solution:**
Provide the parameter to be ignored in the `meqa_init` section or inside the test parameters of `path.yml` with an empty/null as value. If we explicitly mention a parameter as `null`, that parameter is not used in the request.