### PR TITLE
Data assertions

### DIFF
--- a/mqgo/src/meqa/mqgen/main.go
+++ b/mqgo/src/meqa/mqgen/main.go
@@ -44,7 +44,7 @@ func run(meqaPath *string, swaggerFile *string, algorithm *string, verbose *bool
 		os.Exit(1)
 	}
 	whitelistPath := *whitelistFile
-	whitelist := make(map[string]bool)
+	var whitelist map[string]bool
 	if len(whitelistPath) > 0 {
 		if fi, err := os.Stat(whitelistPath); os.IsNotExist(err) || fi.Mode().IsDir() {
 			fmt.Printf("Can't load whitelist file at the following location %s", whitelistPath)

--- a/mqgo/src/meqa/mqgo/main.go
+++ b/mqgo/src/meqa/mqgo/main.go
@@ -10,13 +10,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/satori/go.uuid"
-
 	"meqa/mqplan"
 	"meqa/mqswag"
 	"meqa/mqutil"
 	"path/filepath"
 
+	uuid "github.com/satori/go.uuid"
 	"gopkg.in/resty.v0"
 	"gopkg.in/yaml.v2"
 )
@@ -327,20 +326,32 @@ func runMeqa(meqaPath *string, swaggerFile *string, testPlanFile *string, result
 	resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	resty.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
 
+	resultCounts := make(map[string]int)
 	if *testToRun == "all" {
 		for _, testSuite := range mqplan.Current.SuiteList {
 			mqutil.Logger.Printf("\n---\nTest suite: %s\n", testSuite.Name)
 			fmt.Printf("\n---\nTest suite: %s\n", testSuite.Name)
-			err := mqplan.Current.Run(testSuite.Name, nil)
+			counts, err := mqplan.Current.Run(testSuite.Name, nil)
 			mqutil.Logger.Printf("err:\n%v", err)
+			for k := range counts {
+				resultCounts[k] += counts[k]
+			}
 		}
 	} else {
 		mqutil.Logger.Printf("\n---\nTest suite: %s\n", *testToRun)
 		fmt.Printf("\n---\nTest suite: %s\n", *testToRun)
-		err := mqplan.Current.Run(*testToRun, nil)
+		counts, err := mqplan.Current.Run(*testToRun, nil)
 		mqutil.Logger.Printf("err:\n%v", err)
+		for k := range counts {
+			resultCounts[k] += counts[k]
+		}
 	}
-
+	mqplan.Current.LogErrors()
+	fmt.Printf("%v: %v\n", mqutil.Passed, resultCounts[mqutil.Passed])
+	fmt.Printf("%v: %v\n", mqutil.Failed, resultCounts[mqutil.Failed])
+	fmt.Printf("%v: %v\n", mqutil.Skipped, resultCounts[mqutil.Skipped])
+	fmt.Printf("%v: %v\n", mqutil.SchemaMismatch, resultCounts[mqutil.SchemaMismatch])
+	fmt.Printf("%v: %v\n", mqutil.Total, resultCounts[mqutil.Total])
 	os.Remove(*resultPath)
 	mqplan.Current.WriteResultToFile(*resultPath)
 }

--- a/mqgo/src/meqa/mqgo/main.go
+++ b/mqgo/src/meqa/mqgo/main.go
@@ -326,7 +326,7 @@ func runMeqa(meqaPath *string, swaggerFile *string, testPlanFile *string, result
 	resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	resty.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
 
-	resultCounts := make(map[string]int)
+	mqplan.Current.ResultCounts = make(map[string]int)
 	if *testToRun == "all" {
 		for _, testSuite := range mqplan.Current.SuiteList {
 			mqutil.Logger.Printf("\n---\nTest suite: %s\n", testSuite.Name)
@@ -334,7 +334,7 @@ func runMeqa(meqaPath *string, swaggerFile *string, testPlanFile *string, result
 			counts, err := mqplan.Current.Run(testSuite.Name, nil)
 			mqutil.Logger.Printf("err:\n%v", err)
 			for k := range counts {
-				resultCounts[k] += counts[k]
+				mqplan.Current.ResultCounts[k] += counts[k]
 			}
 		}
 	} else {
@@ -343,15 +343,11 @@ func runMeqa(meqaPath *string, swaggerFile *string, testPlanFile *string, result
 		counts, err := mqplan.Current.Run(*testToRun, nil)
 		mqutil.Logger.Printf("err:\n%v", err)
 		for k := range counts {
-			resultCounts[k] += counts[k]
+			mqplan.Current.ResultCounts[k] += counts[k]
 		}
 	}
 	mqplan.Current.LogErrors()
-	fmt.Printf("%v: %v\n", mqutil.Passed, resultCounts[mqutil.Passed])
-	fmt.Printf("%v: %v\n", mqutil.Failed, resultCounts[mqutil.Failed])
-	fmt.Printf("%v: %v\n", mqutil.Skipped, resultCounts[mqutil.Skipped])
-	fmt.Printf("%v: %v\n", mqutil.SchemaMismatch, resultCounts[mqutil.SchemaMismatch])
-	fmt.Printf("%v: %v\n", mqutil.Total, resultCounts[mqutil.Total])
+	mqplan.Current.PrintSummary()
 	os.Remove(*resultPath)
 	mqplan.Current.WriteResultToFile(*resultPath)
 }

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -1377,7 +1377,8 @@ func (t *Test) GenerateSchema(name string, parentTag *mqswag.MeqaTag, schema *sp
 	}
 
 	if len(schema.Type) == 0 {
-		return nil, mqutil.NewError(mqutil.ErrInvalid, "Parameter doesn't have type")
+		// return nil, mqutil.NewError(mqutil.ErrInvalid, "Parameter doesn't have type")
+		return t.generateObject(name, tag, schema, db, level)
 	}
 	if schema.Type[0] == gojsonschema.TYPE_OBJECT {
 		return t.generateObject(name, tag, schema, db, level)

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -477,6 +477,7 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 			}
 		}
 	} else {
+		t.responseError = resp
 		fmt.Printf("... expecting status: %v got status: %d. Fail\n", expectedStatus, status)
 		setExpect()
 		return mqutil.NewError(mqutil.ErrExpect, fmt.Sprintf("=== test failed, response code %d ===", status))

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -460,8 +460,11 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 		}
 	}
 
+	greenSuccess := fmt.Sprintf("%vSuccess%v", mqutil.GREEN, mqutil.END)
+	redFail := fmt.Sprintf("%vFail%v", mqutil.RED, mqutil.END)
+	yellowFail := fmt.Sprintf("%vFail%v", mqutil.YELLOW, mqutil.END)
 	if testSuccess {
-		fmt.Printf("... expecting status: %v got status: %d. Success\n", expectedStatus, status)
+		fmt.Printf("... expecting status: %v got status: %d. %v\n", expectedStatus, status, greenSuccess)
 		if t.Expect != nil && t.Expect[ExpectBody] != nil {
 			testSuccess = mqutil.InterfaceEquals(t.Expect[ExpectBody], resultObj)
 			if testSuccess {
@@ -478,7 +481,7 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 		}
 	} else {
 		t.responseError = resp
-		fmt.Printf("... expecting status: %v got status: %d. Fail\n", expectedStatus, status)
+		fmt.Printf("... expecting status: %v got status: %d. %v\n", expectedStatus, status, redFail)
 		setExpect()
 		return mqutil.NewError(mqutil.ErrExpect, fmt.Sprintf("=== test failed, response code %d ===", status))
 	}
@@ -490,7 +493,7 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 		fmt.Printf("... verifying response against openapi schema. ")
 		err := respSchema.Parses("", resultObj, collection, true, t.db.Swagger)
 		if err != nil {
-			fmt.Print("Fail\n")
+			fmt.Printf("%v\n", yellowFail)
 			objMatchesSchema = true
 			specBytes, _ := json.MarshalIndent(respSpec, "", "    ")
 			mqutil.Logger.Printf("server response doesn't match swagger spec: \n%s", string(specBytes))
@@ -510,7 +513,7 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 			}
 			*/
 		} else {
-			fmt.Print("Success\n")
+			fmt.Printf("%v\n", greenSuccess)
 		}
 	}
 	if resultObj != nil && len(collection) == 0 && t.tag != nil && len(t.tag.Class) > 0 {

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -118,6 +118,9 @@ type Test struct {
 	op    *spec.Operation
 	resp  *resty.Response
 	err   error
+
+	responseError interface{}
+	schemaError   error
 }
 
 func (t *Test) Init(suite *TestSuite) {
@@ -490,6 +493,7 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 			objMatchesSchema = true
 			specBytes, _ := json.MarshalIndent(respSpec, "", "    ")
 			mqutil.Logger.Printf("server response doesn't match swagger spec: \n%s", string(specBytes))
+			t.schemaError = err
 			if mqutil.Verbose {
 				// fmt.Printf("... openapi response schema: %s\n", string(specBytes))
 				// fmt.Printf("... response body: %s\n", string(respBody))
@@ -539,6 +543,10 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 				mqutil.Logger.Printf("swagger.spec expects a non-empty response, but response body is actually empty")
 			}
 		}
+	}
+	if expectedStatus != "success" {
+		setExpect()
+		return nil
 	}
 
 	// Sometimes the server will return more data than requested. For instance, the server may generate

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -165,6 +165,7 @@ func (t *Test) Duplicate() *Test {
 	test.resp = nil
 	test.comparisons = make(map[string]([]*Comparison))
 	test.err = nil
+	test.db = test.suite.db
 
 	return &test
 }
@@ -606,6 +607,12 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 						}
 					}
 				}
+			}
+		}
+		for className, resultArray := range collection {
+			objTag := mqswag.MeqaTag{className, "", "", 0}
+			for _, c := range resultArray {
+				t.AddObjectComparison(&objTag, c.(map[string]interface{}), (*spec.Schema)(t.db.GetSchema(className)))
 			}
 		}
 	}

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -917,7 +917,9 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			}
 
 			// If there is a parameter passed in, just use it. Otherwise generate one.
-			if paramsMap[params.Name] == nil && globalParamsMap[params.Name] != nil {
+			_, inLocal := paramsMap[params.Name]
+			_, inGlobal := globalParamsMap[params.Name]
+			if !inLocal && inGlobal {
 				paramsMap[params.Name] = globalParamsMap[params.Name]
 			}
 			if _, ok := paramsMap[params.Name]; ok {

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -936,9 +936,11 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 	for _, m := range paramMaps {
 		removeNulls(m)
 	}
-	bodyMap := t.BodyParams.(map[string]interface{})
-	removeNulls(&bodyMap)
-	t.BodyParams = bodyMap
+	if t.BodyParams != nil {
+		bodyMap := t.BodyParams.(map[string]interface{})
+		removeNulls(&bodyMap)
+		t.BodyParams = bodyMap
+	}
 	return nil
 }
 

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -932,7 +932,24 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			return err
 		}
 	}
+	paramMaps := []*map[string]interface{}{&t.PathParams, &t.QueryParams, &t.HeaderParams, &t.FormParams}
+	for _, m := range paramMaps {
+		removeNulls(m)
+	}
+	bodyMap := t.BodyParams.(map[string]interface{})
+	removeNulls(&bodyMap)
+	t.BodyParams = bodyMap
 	return nil
+}
+
+func removeNulls(inputMap *map[string]interface{}) {
+	filteredMap := make(map[string]interface{})
+	for k, v := range *inputMap {
+		if v != nil {
+			filteredMap[k] = v
+		}
+	}
+	*inputMap = filteredMap
 }
 
 func GetOperationByMethod(item *spec.PathItem, method string) *spec.Operation {

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -238,7 +238,7 @@ func (n PathWeightList) Less(i, j int) bool {
 
 // Go through all the paths in swagger, and generate the tests for all the operations under
 // the path.
-func GeneratePathTestPlan(swagger *mqswag.Swagger, dag *mqswag.DAG) (*TestPlan, error) {
+func GeneratePathTestPlan(swagger *mqswag.Swagger, dag *mqswag.DAG, whitelist map[string]bool) (*TestPlan, error) {
 	testPlan := &TestPlan{}
 	testPlan.Init(swagger, nil)
 	testPlan.comment = `
@@ -291,7 +291,9 @@ parameters by default.
 	sort.Sort(pathWeightList)
 
 	for _, p := range pathWeightList {
-		GeneratePathTestSuite(pathMap[p.path], testPlan)
+		if whitelist[p.path] {
+			GeneratePathTestSuite(pathMap[p.path], testPlan)
+		}
 	}
 	return testPlan, nil
 }

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -198,7 +198,9 @@ func GeneratePathTestSuite(operations mqswag.NodeList, plan *TestPlan) {
 			lastParam := GetLastPathParam(o.GetName())
 			if len(lastParam) > 0 {
 				for _, repeatOp := range operations {
-					if lastParam == GetLastPathParam(repeatOp.GetName()) && !OperationMatches(repeatOp, mqswag.MethodDelete) {
+					if lastParam == GetLastPathParam(repeatOp.GetName()) &&
+						!OperationMatches(repeatOp, mqswag.MethodDelete) &&
+						!OperationMatches(repeatOp, mqswag.MethodPost) {
 						testId++
 						repeatTest := CreateTestFromOp(repeatOp, testId)
 						repeatTest.PathParams = make(map[string]interface{})

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -291,7 +291,7 @@ parameters by default.
 	sort.Sort(pathWeightList)
 
 	for _, p := range pathWeightList {
-		if whitelist[p.path] {
+		if whitelist == nil || whitelist[p.path] {
 			GeneratePathTestSuite(pathMap[p.path], testPlan)
 		}
 	}

--- a/mqgo/src/meqa/mqplan/plan.go
+++ b/mqgo/src/meqa/mqplan/plan.go
@@ -255,7 +255,7 @@ func (plan *TestPlan) LogErrors() {
 		}
 		if t.schemaError != nil {
 			fmt.Print(mqutil.YELLOW)
-			fmt.Println(t.schemaError.Error())
+			// fmt.Println(t.schemaError.Error())
 			fmt.Print(mqutil.END)
 		}
 	}

--- a/mqgo/src/meqa/mqplan/plan.go
+++ b/mqgo/src/meqa/mqplan/plan.go
@@ -336,6 +336,7 @@ func (plan *TestPlan) Run(name string, parentTest *Test) (map[string]int, error)
 		}
 		if err != nil {
 			resultCounts[mqutil.Failed]++
+			resultCounts[mqutil.Skipped] = len(tc.Tests) - resultCounts[mqutil.Passed] - 1
 			return resultCounts, err
 		}
 		resultCounts[mqutil.Passed]++

--- a/mqgo/src/meqa/mqplan/plan.go
+++ b/mqgo/src/meqa/mqplan/plan.go
@@ -117,7 +117,8 @@ type TestPlan struct {
 	ApiToken string
 
 	// Run result.
-	resultList []*Test
+	resultList   []*Test
+	ResultCounts map[string]int
 
 	comment string
 }
@@ -236,22 +237,47 @@ func (plan *TestPlan) WriteResultToFile(path string) error {
 }
 
 func (plan *TestPlan) LogErrors() {
-	fmt.Println("-----------------------------Errors----------------------------------")
+	fmt.Print(mqutil.AQUA)
+	fmt.Printf("-----------------------------Errors----------------------------------\n")
+	fmt.Print(mqutil.END)
 	for _, t := range plan.resultList {
 		if t.responseError != nil || t.schemaError != nil {
+			fmt.Print(mqutil.AQUA)
 			fmt.Println("--------")
 			fmt.Printf("%v: %v\n", t.Path, t.Name)
+			fmt.Print(mqutil.END)
 		}
 		if t.responseError != nil {
+			fmt.Print(mqutil.RED)
 			fmt.Println("Response Status Code:", t.resp.StatusCode())
 			fmt.Println(t.responseError)
+			fmt.Print(mqutil.END)
 		}
 		if t.schemaError != nil {
+			fmt.Print(mqutil.YELLOW)
 			fmt.Println(t.schemaError.Error())
+			fmt.Print(mqutil.END)
 		}
 	}
+	fmt.Print(mqutil.AQUA)
 	fmt.Println("---------------------------------------------------------------------")
+	fmt.Print(mqutil.END)
 }
+
+func (plan *TestPlan) PrintSummary() {
+	fmt.Print(mqutil.GREEN)
+	fmt.Printf("%v: %v\n", mqutil.Passed, plan.ResultCounts[mqutil.Passed])
+	fmt.Print(mqutil.RED)
+	fmt.Printf("%v: %v\n", mqutil.Failed, plan.ResultCounts[mqutil.Failed])
+	fmt.Print(mqutil.BLUE)
+	fmt.Printf("%v: %v\n", mqutil.Skipped, plan.ResultCounts[mqutil.Skipped])
+	fmt.Print(mqutil.YELLOW)
+	fmt.Printf("%v: %v\n", mqutil.SchemaMismatch, plan.ResultCounts[mqutil.SchemaMismatch])
+	fmt.Print(mqutil.AQUA)
+	fmt.Printf("%v: %v\n", mqutil.Total, plan.ResultCounts[mqutil.Total])
+	fmt.Print(mqutil.END)
+}
+
 func (plan *TestPlan) Init(swagger *mqswag.Swagger, db *mqswag.DB) {
 	plan.db = db
 	plan.swagger = swagger

--- a/mqgo/src/meqa/mqswag/db.go
+++ b/mqgo/src/meqa/mqswag/db.go
@@ -157,7 +157,7 @@ func (schema *Schema) Parses(name string, object interface{}, collection map[str
 	} else if k == reflect.Map {
 		isProperty = false
 		objMap, objIsMap := object.(map[string]interface{})
-		if !objIsMap || !schema.Type.Contains(gojsonschema.TYPE_OBJECT) {
+		if !objIsMap { // || !schema.Type.Contains(gojsonschema.TYPE_OBJECT) {
 			return raiseError("schema is not an object")
 		}
 		for _, requiredName := range schema.Required {

--- a/mqgo/src/meqa/mqswag/parser.go
+++ b/mqgo/src/meqa/mqswag/parser.go
@@ -167,6 +167,20 @@ func CreateSwaggerFromURL(path string, meqaPath string) (*Swagger, error) {
 	return (*Swagger)(specDoc.Spec()), nil
 }
 
+func GetWhitelistSuites(path string) (map[string]bool, error) {
+	whitelistBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		mqutil.Logger.Printf("can't read file %s", path)
+		return nil, err
+	}
+	suites := strings.Split(string(whitelistBytes), "\n")
+	whitelist := make(map[string]bool)
+	for _, suite := range suites {
+		whitelist[suite] = true
+	}
+	return whitelist, nil
+}
+
 // FindSchemaByName finds the schema defined by name in the swagger document.
 func (swagger *Swagger) FindSchemaByName(name string) *Schema {
 	schema, ok := swagger.Definitions[name]

--- a/mqgo/src/meqa/mqutil/logging.go
+++ b/mqgo/src/meqa/mqutil/logging.go
@@ -7,6 +7,15 @@ import (
 	"os"
 )
 
+// Test results constants
+const (
+	Passed         = "Passed"
+	Failed         = "Failed"
+	Skipped        = "Skipped"
+	SchemaMismatch = "SchemaMismatch"
+	Total          = "Total"
+)
+
 func NewLogger(out io.Writer) *log.Logger {
 	Logger = log.New(out, "", (log.Ldate | log.Lmicroseconds | log.Lshortfile))
 	return Logger

--- a/mqgo/src/meqa/mqutil/logging.go
+++ b/mqgo/src/meqa/mqutil/logging.go
@@ -16,6 +16,16 @@ const (
 	Total          = "Total"
 )
 
+// Colors for better logging
+const (
+	RED    = "\033[1;31m"
+	GREEN  = "\033[1;32m"
+	YELLOW = "\033[1;33m"
+	BLUE   = "\033[1;34m"
+	AQUA   = "\033[1;36m"
+	END    = "\033[0m"
+)
+
 func NewLogger(out io.Writer) *log.Logger {
 	Logger = log.New(out, "", (log.Ldate | log.Lmicroseconds | log.Lshortfile))
 	return Logger

--- a/mqgo/src/meqa/mqutil/map.go
+++ b/mqgo/src/meqa/mqutil/map.go
@@ -176,7 +176,7 @@ func InterfaceEquals(criteria interface{}, existing interface{}) bool {
 			return true
 		} else {
 			existingKind := reflect.TypeOf(existing).Kind()
-			if existingKind == reflect.Map || existingKind == reflect.Array {
+			if existingKind == reflect.Map || existingKind == reflect.Array || existingKind == reflect.Slice {
 				return true
 			}
 			return false
@@ -223,6 +223,9 @@ func InterfaceEquals(criteria interface{}, existing interface{}) bool {
 			}
 		}
 		return true
+	}
+	if eKind == reflect.String && (cKind == reflect.Int || cKind == reflect.Float32 || cKind == reflect.Float64) {
+		return reflect.TypeOf(existing).String() == "json.Number"
 	}
 
 	cJson, _ := json.Marshal(criteria)


### PR DESCRIPTION
Add content/data assertions:
- Common fields between request and response should match
  - For POST and PUT requests
  - Arrays are not compared
- Assertions across requests
  - Responses of POST and subsequent GET should match
  - After a POST request, the object is added to the test suite's in-mem db
  - During GET, the object in the db is searched against the returned results

Changes:
- Original implementation checked every returned result against the db. This would fail for endpoints which list objects.
So modified to check db objects against returned results.
But if there are multiple objects in db (possible if a single POST creates multiple objects) and we query for a single object, it would fail.
- Test db was global. Helps when there's cross-suite dependency (ie. One object takes a previously created object). But we're deleting the object in the end of every suite.
So changed db scope to the respective test suite
- Body parameters are first randomly generated then replaced with values provided. This caused incorrect data to be added to the in-mem db.
Modified to prevent generation if the parameter is provided.
- When an object is created using its `CreateDefinition` and the response contains `ObjectModel` which is a combination of `CreateDefinition` and `MetadataModel`, only the the `CreateDefinition` is added to db.
Modified to add all definitions/models to db for later assertions.

